### PR TITLE
Mod: allow many theme colors

### DIFF
--- a/jquery.highchartTable.js
+++ b/jquery.highchartTable.js
@@ -315,7 +315,8 @@
       var lineShadow  = $table.data('graph-line-shadow');
       var lineWidth   = $table.data('graph-line-width') || 2;
 
-      for(var i=0; i<9; i++) {
+      var nbOfColors = Math.max(defaultColors.length, themeColors.length);
+      for(var i=0; i < nbOfColors; i++) {
         var dataname = 'graph-color-' + (i+1);
         colors.push(typeof $table.data(dataname) != 'undefined' ? $table.data(dataname) : typeof themeColors[i] != 'undefined' ? themeColors[i] : defaultColors[i]);
       }


### PR DESCRIPTION
Modification du plugin highchartstable pour qu'il prenne en compte des thèmes comportant plus que 10 couleurs.

(Besoin : le camembert à 13 parts qu'on a dans les nouveaux écrans du backend.)

Ping @cGuille et @johanpoirier, allez.
